### PR TITLE
Changed 'App' command to use folder and not file.

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "echo lol",
     <%_ if (type === 'electron') { -%>
-    "app": "electron app/index.js",
+    "app": "electron app/",
     "dist": "npm run dist:mac && npm run dist:win && npm run dist:linux",
     "dist:mac": "build --mac",
     "dist:win": "build --win --ia32",


### PR DESCRIPTION
There are a few issues with selecting the js file as the runner instead of the folder. Electron will not read the project.json file in app. Any functions that use that information, such as getting the "userData" path, will not return the desired result.

Here is a [reference](http://stackoverflow.com/questions/35630934/app-getpathuserdata-seems-to-give-the-wrong-path) to that problem.