### PR TITLE
Fix typo in prompt text (descripe -> describe)

### DIFF
--- a/sao.js
+++ b/sao.js
@@ -7,7 +7,7 @@ module.exports = {
       default: ':folderName:'
     },
     description: {
-      message: 'How would your descripe your superb project',
+      message: 'How would your describe your superb project',
       default: `My ${superb()} Vue project`
     },
     pwa: {


### PR DESCRIPTION
Noticed a typo, so I thought I'll make a tiny contribution :)